### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-website.yaml
+++ b/.github/workflows/docs-website.yaml
@@ -20,6 +20,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Build (Docs)
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/SpechtLabs/CalendarAPI/security/code-scanning/1](https://github.com/SpechtLabs/CalendarAPI/security/code-scanning/1)

To fix the issue, we need to add an explicit `permissions` block to the `build` job. Since the job only involves reading repository contents and uploading artifacts, the minimal required permission is `contents: read`. This change ensures that the `build` job adheres to the principle of least privilege and does not inherit unnecessary permissions from the repository.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
